### PR TITLE
Minor changes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,5 @@
 
 Instruction
 
-MinesSeeker is an Android App for playing mines seeker game. The game if pretty much similiar to the well known old classic mine 
-seeker game. Users are able to set up the game size i.e. the size of the board. Since the board is essentially a mxn matrix, users 
-are able to set up the number of columns and the number of rows manually. In addition to that, users are able to select the number
-of mines/treasures there are in the game. During the game, when the user click on a grid with a mine, the grid will reveal the mine.
-If user clicked a grid without a mine, a numerical number will be revealed. Such number is the representation of the sum of the 
-number of mines there are in the selected column and row. The goal of this game is to find all the mines within a short time. 
-The total time of user clicked the grid will be recorded, less the time the better result.
+MinesSeeker is an Android App for playing mines seeker game. The game is pretty much similiar to the well known classic mine seeker game. User are able to set up the game size by switching the board size. Since the board is essentially a mxn matrix, users are able to set up the number of columns and the number of rows manually. Users are able to select the number of mines/treasures. During the game, when the user click on a grid with a mine, the mine will be revealed. If the user clicked a grid without a mine, a numerical number will be revealed. Such number is the sum of the number of mines counted in the selected column and row. The goal of this game is to find all the mines within a short time. The total time of user clicked the grid is recorded. The user with least amount of recorded click time will be the winner.
 


### PR DESCRIPTION
-Changed “old classic mine seeker game” to “classic mine seeker game” to avoid redundancy.

-Changed “Users are able to set up the game size i.e. the size of the board” to “User are able to set up the game size by switching the board size” to be more concise.

-Deleted “In addition to that”, first reason is “that” is not clearly referenced, second reason is it is considered as a Fake Coherence word.

-Deleted “there are in the game”, the actual meaning of these words are useless. Because we are talking about the game, no further specifications are needed.

-Changed “the representation of the sum of…” to "the sum of” because sum is the representation, avoided redundancy.

-Changed the last sentence “less the time the better result” to “The user with least amount of recorded click time will be the winner” to be more grammarly correct and express 
more accurate meaning
